### PR TITLE
Add xDAI to ChainId

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,8 @@ export enum ChainId {
   ROPSTEN = 3,
   RINKEBY = 4,
   GÖRLI = 5,
-  KOVAN = 42
+  KOVAN = 42,
+  XDAI = 100
 }
 
 export enum TradeType {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,7 @@ interface FactoryParams {
   initCode: string
 }
 
-export function getFactory (chainId: ChainId): FactoryParams  {
+export function getFactoryParams (chainId: ChainId): FactoryParams  {
   if (chainId === ChainId.XDAI) {
     return {
       factoryAddress: FACTORY_ADDRESS_XDAI,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,9 +23,34 @@ export enum Rounding {
   ROUND_UP
 }
 
-export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+const INIT_CODE_HASH = '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f'
 
-export const INIT_CODE_HASH = '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f'
+const FACTORY_ADDRESS_XDAI = '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7'
+const INIT_CODE_HASH_XDAI = '0x3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93'
+
+
+interface FactoryParams {
+  factoryAddress: string,
+  initCode: string
+}
+
+export function getFactory (chainId: ChainId): FactoryParams  {
+  if (chainId === ChainId.XDAI) {
+    return {
+      factoryAddress: FACTORY_ADDRESS_XDAI,
+      initCode: INIT_CODE_HASH_XDAI
+    }
+  } else {
+    return {
+      factoryAddress: FACTORY_ADDRESS,
+      initCode: INIT_CODE_HASH
+    }
+  }
+}
+
+
+
 
 export const MINIMUM_LIQUIDITY = JSBI.BigInt(1000)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,13 +29,12 @@ const INIT_CODE_HASH = '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e
 const FACTORY_ADDRESS_XDAI = '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7'
 const INIT_CODE_HASH_XDAI = '0x3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93'
 
-
 interface FactoryParams {
-  factoryAddress: string,
+  factoryAddress: string
   initCode: string
 }
 
-export function getFactoryParams (chainId: ChainId): FactoryParams  {
+export function getFactoryParams(chainId: ChainId): FactoryParams {
   if (chainId === ChainId.XDAI) {
     return {
       factoryAddress: FACTORY_ADDRESS_XDAI,
@@ -48,9 +47,6 @@ export function getFactoryParams (chainId: ChainId): FactoryParams  {
     }
   }
 }
-
-
-
 
 export const MINIMUM_LIQUIDITY = JSBI.BigInt(1000)
 

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -7,7 +7,7 @@ import { getCreate2Address } from '@ethersproject/address'
 
 import {
   BigintIsh,
-  getFactory,
+  getFactoryParams,
   MINIMUM_LIQUIDITY,
   ZERO,
   ONE,
@@ -29,7 +29,7 @@ export class Pair {
   public static getAddress(tokenA: Token, tokenB: Token): string {
     const tokens = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA] // does safety checks
 
-    const { factoryAddress, initCode } = getFactory(tokenA.chainId)
+    const { factoryAddress, initCode } = getFactoryParams(tokenA.chainId)
 
 
     if (PAIR_ADDRESS_CACHE?.[tokens[0].address]?.[tokens[1].address] === undefined) {

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -7,8 +7,7 @@ import { getCreate2Address } from '@ethersproject/address'
 
 import {
   BigintIsh,
-  FACTORY_ADDRESS,
-  INIT_CODE_HASH,
+  getFactory,
   MINIMUM_LIQUIDITY,
   ZERO,
   ONE,
@@ -30,15 +29,18 @@ export class Pair {
   public static getAddress(tokenA: Token, tokenB: Token): string {
     const tokens = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA] // does safety checks
 
+    const { factoryAddress, initCode } = getFactory(tokenA.chainId)
+
+
     if (PAIR_ADDRESS_CACHE?.[tokens[0].address]?.[tokens[1].address] === undefined) {
       PAIR_ADDRESS_CACHE = {
         ...PAIR_ADDRESS_CACHE,
         [tokens[0].address]: {
           ...PAIR_ADDRESS_CACHE?.[tokens[0].address],
           [tokens[1].address]: getCreate2Address(
-            FACTORY_ADDRESS,
+            factoryAddress,
             keccak256(['bytes'], [pack(['address', 'address'], [tokens[0].address, tokens[1].address])]),
-            INIT_CODE_HASH
+            initCode
           )
         }
       }

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -5,17 +5,7 @@ import JSBI from 'jsbi'
 import { pack, keccak256 } from '@ethersproject/solidity'
 import { getCreate2Address } from '@ethersproject/address'
 
-import {
-  BigintIsh,
-  getFactoryParams,
-  MINIMUM_LIQUIDITY,
-  ZERO,
-  ONE,
-  FIVE,
-  _997,
-  _1000,
-  ChainId
-} from '../constants'
+import { BigintIsh, getFactoryParams, MINIMUM_LIQUIDITY, ZERO, ONE, FIVE, _997, _1000, ChainId } from '../constants'
 import { sqrt, parseBigintIsh } from '../utils'
 import { InsufficientReservesError, InsufficientInputAmountError } from '../errors'
 import { Token } from './token'
@@ -30,7 +20,6 @@ export class Pair {
     const tokens = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA] // does safety checks
 
     const { factoryAddress, initCode } = getFactoryParams(tokenA.chainId)
-
 
     if (PAIR_ADDRESS_CACHE?.[tokens[0].address]?.[tokens[1].address] === undefined) {
       PAIR_ADDRESS_CACHE = {

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -79,5 +79,12 @@ export const WETH = {
     'Wrapped Ether'
   ),
   [ChainId.GÖRLI]: new Token(ChainId.GÖRLI, '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', 18, 'WETH', 'Wrapped Ether'),
-  [ChainId.KOVAN]: new Token(ChainId.KOVAN, '0xd0A1E359811322d97991E03f863a0C30C2cF029C', 18, 'WETH', 'Wrapped Ether')
+  [ChainId.KOVAN]: new Token(ChainId.KOVAN, '0xd0A1E359811322d97991E03f863a0C30C2cF029C', 18, 'WETH', 'Wrapped Ether'),
+  [ChainId.XDAI]: new Token(
+    ChainId.XDAI,
+    '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
+    18,
+    'WXDAI',
+    'Wrapped XDAI'
+  )
 }

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -80,11 +80,5 @@ export const WETH = {
   ),
   [ChainId.GÖRLI]: new Token(ChainId.GÖRLI, '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', 18, 'WETH', 'Wrapped Ether'),
   [ChainId.KOVAN]: new Token(ChainId.KOVAN, '0xd0A1E359811322d97991E03f863a0C30C2cF029C', 18, 'WETH', 'Wrapped Ether'),
-  [ChainId.XDAI]: new Token(
-    ChainId.XDAI,
-    '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
-    18,
-    'WXDAI',
-    'Wrapped XDAI'
-  )
+  [ChainId.XDAI]: new Token(ChainId.XDAI, '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d', 18, 'WXDAI', 'Wrapped XDAI')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,7 @@ export {
   ChainId,
   TradeType,
   Rounding,
-  FACTORY_ADDRESS,
-  INIT_CODE_HASH,
+  getFactory,
   MINIMUM_LIQUIDITY
 } from './constants'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export {
   ChainId,
   TradeType,
   Rounding,
-  getFactory,
+  getFactoryParams,
   MINIMUM_LIQUIDITY
 } from './constants'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,7 @@
 import JSBI from 'jsbi'
 export { JSBI }
 
-export {
-  BigintIsh,
-  ChainId,
-  TradeType,
-  Rounding,
-  getFactoryParams,
-  MINIMUM_LIQUIDITY
-} from './constants'
+export { BigintIsh, ChainId, TradeType, Rounding, getFactoryParams, MINIMUM_LIQUIDITY } from './constants'
 
 export * from './errors'
 export * from './entities'

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,4 +1,4 @@
-import { INIT_CODE_HASH } from '../src/constants'
+import { ChainId, getFactoryParams } from '../src/constants'
 
 import { bytecode } from '@uniswap/v2-core/build/UniswapV2Pair.json'
 import { keccak256 } from '@ethersproject/solidity'
@@ -10,7 +10,8 @@ const COMPUTED_INIT_CODE_HASH = keccak256(['bytes'], [`0x${bytecode}`])
 describe('constants', () => {
   describe('INIT_CODE_HASH', () => {
     it('matches computed bytecode hash', () => {
-      expect(COMPUTED_INIT_CODE_HASH).toEqual(INIT_CODE_HASH)
+      const { initCode } = getFactoryParams(ChainId.MAINNET)
+      expect(COMPUTED_INIT_CODE_HASH).toEqual(initCode)
     })
   })
 })


### PR DESCRIPTION
Closes #52 

Adds xDAI support in the SDK

The constants for the factory/init code are not exported any more. They depend on the current network. A new function `getFactoryParams` is exported instead. 