### PR TITLE
Support any network

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,8 @@ export enum ChainId {
   ROPSTEN = 3,
   RINKEBY = 4,
   GÖRLI = 5,
-  KOVAN = 42
+  KOVAN = 42,
+  XDAI = 100
 }
 
 export enum TradeType {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import JSBI from 'jsbi'
 // exports for external consumption
 export type BigintIsh = JSBI | bigint | string
 
-export enum ChainId {
+export enum Chain {
   MAINNET = 1,
   ROPSTEN = 3,
   RINKEBY = 4,
@@ -11,6 +11,8 @@ export enum ChainId {
   KOVAN = 42,
   XDAI = 100
 }
+
+export type ChainId = number
 
 export enum TradeType {
   EXACT_INPUT,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,9 +25,30 @@ export enum Rounding {
   ROUND_UP
 }
 
-export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+const INIT_CODE_HASH = '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f'
 
-export const INIT_CODE_HASH = '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f'
+const FACTORY_ADDRESS_XDAI = '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7'
+const INIT_CODE_HASH_XDAI = '0x3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93'
+
+interface FactoryParams {
+  factoryAddress: string
+  initCode: string
+}
+
+export function getFactoryParams(chainId: ChainId): FactoryParams {
+  if (chainId === ChainId.XDAI) {
+    return {
+      factoryAddress: FACTORY_ADDRESS_XDAI,
+      initCode: INIT_CODE_HASH_XDAI
+    }
+  } else {
+    return {
+      factoryAddress: FACTORY_ADDRESS,
+      initCode: INIT_CODE_HASH
+    }
+  }
+}
 
 export const MINIMUM_LIQUIDITY = JSBI.BigInt(1000)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,7 +37,7 @@ interface FactoryParams {
 }
 
 export function getFactoryParams(chainId: ChainId): FactoryParams {
-  if (chainId === ChainId.XDAI) {
+  if (chainId === Chain.XDAI) {
     return {
       factoryAddress: FACTORY_ADDRESS_XDAI,
       initCode: INIT_CODE_HASH_XDAI

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -5,18 +5,7 @@ import JSBI from 'jsbi'
 import { pack, keccak256 } from '@ethersproject/solidity'
 import { getCreate2Address } from '@ethersproject/address'
 
-import {
-  BigintIsh,
-  FACTORY_ADDRESS,
-  INIT_CODE_HASH,
-  MINIMUM_LIQUIDITY,
-  ZERO,
-  ONE,
-  FIVE,
-  _997,
-  _1000,
-  ChainId
-} from '../constants'
+import { BigintIsh, getFactoryParams, MINIMUM_LIQUIDITY, ZERO, ONE, FIVE, _997, _1000, ChainId } from '../constants'
 import { sqrt, parseBigintIsh } from '../utils'
 import { InsufficientReservesError, InsufficientInputAmountError } from '../errors'
 import { Token } from './token'
@@ -30,15 +19,17 @@ export class Pair {
   public static getAddress(tokenA: Token, tokenB: Token): string {
     const tokens = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA] // does safety checks
 
+    const { factoryAddress, initCode } = getFactoryParams(tokenA.chainId)
+
     if (PAIR_ADDRESS_CACHE?.[tokens[0].address]?.[tokens[1].address] === undefined) {
       PAIR_ADDRESS_CACHE = {
         ...PAIR_ADDRESS_CACHE,
         [tokens[0].address]: {
           ...PAIR_ADDRESS_CACHE?.[tokens[0].address],
           [tokens[1].address]: getCreate2Address(
-            FACTORY_ADDRESS,
+            factoryAddress,
             keccak256(['bytes'], [pack(['address', 'address'], [tokens[0].address, tokens[1].address])]),
-            INIT_CODE_HASH
+            initCode
           )
         }
       }

--- a/src/entities/route.ts
+++ b/src/entities/route.ts
@@ -14,6 +14,7 @@ export class Route {
   public readonly midPrice: Price
 
   public constructor(pairs: Pair[], input: Currency, output?: Currency) {
+    const weth = WETH[pairs[0].chainId]
     invariant(pairs.length > 0, 'PAIRS')
     invariant(
       pairs.every(pair => pair.chainId === pairs[0].chainId),
@@ -21,17 +22,17 @@ export class Route {
     )
     invariant(
       (input instanceof Token && pairs[0].involvesToken(input)) ||
-        (input === ETHER && pairs[0].involvesToken(WETH[pairs[0].chainId])),
+        (input === ETHER && weth && pairs[0].involvesToken(weth)),
       'INPUT'
     )
     invariant(
       typeof output === 'undefined' ||
         (output instanceof Token && pairs[pairs.length - 1].involvesToken(output)) ||
-        (output === ETHER && pairs[pairs.length - 1].involvesToken(WETH[pairs[0].chainId])),
+        (output === ETHER && weth && pairs[pairs.length - 1].involvesToken(weth)),
       'OUTPUT'
     )
 
-    const path: Token[] = [input instanceof Token ? input : WETH[pairs[0].chainId]]
+    const path: Token[] = [input instanceof Token ? input : weth!]
     for (const [i, pair] of pairs.entries()) {
       const currentInput = path[i]
       invariant(currentInput.equals(pair.token0) || currentInput.equals(pair.token1), 'PATH')

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { ChainId } from '../constants'
+import { Chain, ChainId } from '../constants'
 import { validateAndParseAddress } from '../utils'
 import { Currency } from './currency'
 
@@ -56,28 +56,38 @@ export function currencyEquals(currencyA: Currency, currencyB: Currency): boolea
   }
 }
 
-export const WETH = {
-  [ChainId.MAINNET]: new Token(
-    ChainId.MAINNET,
-    '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.ROPSTEN]: new Token(
-    ChainId.ROPSTEN,
-    '0xc778417E063141139Fce010982780140Aa0cD5Ab',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.RINKEBY]: new Token(
-    ChainId.RINKEBY,
-    '0xc778417E063141139Fce010982780140Aa0cD5Ab',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.GÖRLI]: new Token(ChainId.GÖRLI, '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', 18, 'WETH', 'Wrapped Ether'),
-  [ChainId.KOVAN]: new Token(ChainId.KOVAN, '0xd0A1E359811322d97991E03f863a0C30C2cF029C', 18, 'WETH', 'Wrapped Ether')
+export const WETH_MAINNET = new Token(
+  Chain.MAINNET,
+  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  18,
+  'WETH',
+  'Wrapped Ether'
+)
+
+export const WETH_ROPSTEN = new Token(
+  Chain.ROPSTEN,
+  '0xc778417E063141139Fce010982780140Aa0cD5Ab',
+  18,
+  'WETH',
+  'Wrapped Ether'
+)
+
+export const WETH_RINKEBY = new Token(
+  Chain.RINKEBY,
+  '0xc778417E063141139Fce010982780140Aa0cD5Ab',
+  18,
+  'WETH',
+  'Wrapped Ether'
+)
+
+export const WETH_GÖRLI = new Token(Chain.GÖRLI, '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', 18, 'WETH', 'Wrapped Ether')
+export const WETH_KOVAN = new Token(Chain.KOVAN, '0xd0A1E359811322d97991E03f863a0C30C2cF029C', 18, 'WETH', 'Wrapped Ether')
+
+
+export const WETH: Partial<Record<ChainId, Token>> = {  
+  [Chain.MAINNET]: WETH_MAINNET,
+  [Chain.ROPSTEN]: WETH_ROPSTEN,
+  [Chain.RINKEBY]: WETH_RINKEBY,
+  [Chain.GÖRLI]: WETH_GÖRLI,
+  [Chain.KOVAN]: WETH_KOVAN
 }

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -80,11 +80,22 @@ export const WETH_RINKEBY = new Token(
   'Wrapped Ether'
 )
 
-export const WETH_GÖRLI = new Token(Chain.GÖRLI, '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', 18, 'WETH', 'Wrapped Ether')
-export const WETH_KOVAN = new Token(Chain.KOVAN, '0xd0A1E359811322d97991E03f863a0C30C2cF029C', 18, 'WETH', 'Wrapped Ether')
+export const WETH_GÖRLI = new Token(
+  Chain.GÖRLI,
+  '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+  18,
+  'WETH',
+  'Wrapped Ether'
+)
+export const WETH_KOVAN = new Token(
+  Chain.KOVAN,
+  '0xd0A1E359811322d97991E03f863a0C30C2cF029C',
+  18,
+  'WETH',
+  'Wrapped Ether'
+)
 
-
-export const WETH: Partial<Record<ChainId, Token>> = {  
+export const WETH: Partial<Record<ChainId, Token>> = {
   [Chain.MAINNET]: WETH_MAINNET,
   [Chain.ROPSTEN]: WETH_ROPSTEN,
   [Chain.RINKEBY]: WETH_RINKEBY,

--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -89,13 +89,19 @@ export interface BestTradeOptions {
  */
 function wrappedAmount(currencyAmount: CurrencyAmount, chainId: ChainId): TokenAmount {
   if (currencyAmount instanceof TokenAmount) return currencyAmount
-  if (currencyAmount.currency === ETHER) return new TokenAmount(WETH[chainId], currencyAmount.raw)
+  if (currencyAmount.currency === ETHER) {
+    const weth = WETH[chainId]
+    if (weth) return new TokenAmount(weth, currencyAmount.raw)
+  }
   invariant(false, 'CURRENCY')
 }
 
 function wrappedCurrency(currency: Currency, chainId: ChainId): Token {
   if (currency instanceof Token) return currency
-  if (currency === ETHER) return WETH[chainId]
+  if (currency === ETHER) {
+    const weth = WETH[chainId]
+    if (weth) return weth
+  }
   invariant(false, 'CURRENCY')
 }
 

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -6,11 +6,11 @@ import { Pair } from './entities/pair'
 import IUniswapV2Pair from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import invariant from 'tiny-invariant'
 import ERC20 from './abis/ERC20.json'
-import { ChainId } from './constants'
+import { ChainId, Chain } from './constants'
 import { Token } from './entities/token'
 
 let TOKEN_DECIMALS_CACHE: { [chainId: number]: { [address: string]: number } } = {
-  [ChainId.MAINNET]: {
+  [Chain.MAINNET]: {
     '0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A': 9 // DGD
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export {
   Rounding,
   FACTORY_ADDRESS,
   INIT_CODE_HASH,
-  MINIMUM_LIQUIDITY,
+  MINIMUM_LIQUIDITY
 } from './constants'
 
 export * from './errors'

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,13 @@ export { JSBI }
 
 export {
   BigintIsh,
+  Chain,
   ChainId,
   TradeType,
   Rounding,
   FACTORY_ADDRESS,
   INIT_CODE_HASH,
-  MINIMUM_LIQUIDITY
+  MINIMUM_LIQUIDITY,
 } from './constants'
 
 export * from './errors'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,7 @@
 import JSBI from 'jsbi'
 export { JSBI }
 
-export {
-  BigintIsh,
-  Chain,
-  ChainId,
-  TradeType,
-  Rounding,
-  FACTORY_ADDRESS,
-  INIT_CODE_HASH,
-  MINIMUM_LIQUIDITY
-} from './constants'
+export { BigintIsh, Chain, ChainId, TradeType, Rounding, getFactoryParams, MINIMUM_LIQUIDITY } from './constants'
 
 export * from './errors'
 export * from './entities'

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,4 +1,4 @@
-import { INIT_CODE_HASH } from '../src/constants'
+import { ChainId, getFactoryParams } from '../src/constants'
 
 import { bytecode } from '@uniswap/v2-core/build/UniswapV2Pair.json'
 import { keccak256 } from '@ethersproject/solidity'
@@ -10,7 +10,8 @@ const COMPUTED_INIT_CODE_HASH = keccak256(['bytes'], [`0x${bytecode}`])
 describe('constants', () => {
   describe('INIT_CODE_HASH', () => {
     it('matches computed bytecode hash', () => {
-      expect(COMPUTED_INIT_CODE_HASH).toEqual(INIT_CODE_HASH)
+      const { initCode } = getFactoryParams(ChainId.MAINNET)
+      expect(COMPUTED_INIT_CODE_HASH).toEqual(initCode)
     })
   })
 })

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,4 +1,4 @@
-import { ChainId, getFactoryParams } from '../src/constants'
+import { Chain, getFactoryParams } from '../src/constants'
 
 import { bytecode } from '@uniswap/v2-core/build/UniswapV2Pair.json'
 import { keccak256 } from '@ethersproject/solidity'
@@ -10,7 +10,7 @@ const COMPUTED_INIT_CODE_HASH = keccak256(['bytes'], [`0x${bytecode}`])
 describe('constants', () => {
   describe('INIT_CODE_HASH', () => {
     it('matches computed bytecode hash', () => {
-      const { initCode } = getFactoryParams(ChainId.MAINNET)
+      const { initCode } = getFactoryParams(Chain.MAINNET)
       expect(COMPUTED_INIT_CODE_HASH).toEqual(initCode)
     })
   })

--- a/test/data.test.ts
+++ b/test/data.test.ts
@@ -1,20 +1,20 @@
-import { ChainId, WETH, Token, Fetcher } from '../src'
+import { Chain, WETH_RINKEBY, Token, Fetcher } from '../src'
 
 // TODO: replace the provider in these tests
 describe.skip('data', () => {
   it('Token', async () => {
-    const token = await Fetcher.fetchTokenData(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F') // DAI
+    const token = await Fetcher.fetchTokenData(Chain.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F') // DAI
     expect(token.decimals).toEqual(18)
   })
 
   it('Token:CACHE', async () => {
-    const token = await Fetcher.fetchTokenData(ChainId.MAINNET, '0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A') // DGD
+    const token = await Fetcher.fetchTokenData(Chain.MAINNET, '0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A') // DGD
     expect(token.decimals).toEqual(9)
   })
 
   it('Pair', async () => {
-    const token = new Token(ChainId.RINKEBY, '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735', 18) // DAI
-    const pair = await Fetcher.fetchPairData(WETH[ChainId.RINKEBY], token)
+    const token = new Token(Chain.RINKEBY, '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735', 18) // DAI
+    const pair = await Fetcher.fetchPairData(WETH_RINKEBY, token)
     expect(pair.liquidityToken.address).toEqual('0x8B22F85d0c844Cf793690F6D9DFE9F11Ddb35449')
   })
 })

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -1,13 +1,13 @@
 import invariant from 'tiny-invariant'
-import { ChainId, WETH as _WETH, TradeType, Rounding, Token, TokenAmount, Pair, Route, Trade } from '../src'
+import { Chain, TradeType, Rounding, Token, TokenAmount, Pair, Route, Trade, WETH_RINKEBY } from '../src'
 
 const ADDRESSES = [
   '0x0000000000000000000000000000000000000001',
   '0x0000000000000000000000000000000000000002',
   '0x0000000000000000000000000000000000000003'
 ]
-const CHAIN_ID = ChainId.RINKEBY
-const WETH = _WETH[ChainId.RINKEBY]
+const CHAIN_ID = Chain.RINKEBY
+const WETH = WETH_RINKEBY
 const DECIMAL_PERMUTATIONS: [number, number, number][] = [
   [0, 0, 0],
   [0, 9, 18],

--- a/test/miscellaneous.test.ts
+++ b/test/miscellaneous.test.ts
@@ -1,10 +1,10 @@
-import { ChainId, Token, TokenAmount, Pair, InsufficientInputAmountError } from '../src'
+import { Chain, Token, TokenAmount, Pair, InsufficientInputAmountError } from '../src'
 import { sortedInsert } from '../src/utils'
 
 describe('miscellaneous', () => {
   it('getLiquidityMinted:0', async () => {
-    const tokenA = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
-    const tokenB = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
+    const tokenA = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
+    const tokenB = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
     const pair = new Pair(new TokenAmount(tokenA, '0'), new TokenAmount(tokenB, '0'))
 
     expect(() => {
@@ -33,8 +33,8 @@ describe('miscellaneous', () => {
   })
 
   it('getLiquidityMinted:!0', async () => {
-    const tokenA = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
-    const tokenB = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
+    const tokenA = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
+    const tokenB = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
     const pair = new Pair(new TokenAmount(tokenA, '10000'), new TokenAmount(tokenB, '10000'))
 
     expect(
@@ -49,8 +49,8 @@ describe('miscellaneous', () => {
   })
 
   it('getLiquidityValue:!feeOn', async () => {
-    const tokenA = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
-    const tokenB = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
+    const tokenA = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
+    const tokenB = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
     const pair = new Pair(new TokenAmount(tokenA, '1000'), new TokenAmount(tokenB, '1000'))
 
     {
@@ -90,8 +90,8 @@ describe('miscellaneous', () => {
   })
 
   it('getLiquidityValue:feeOn', async () => {
-    const tokenA = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
-    const tokenB = new Token(ChainId.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
+    const tokenA = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000001', 18)
+    const tokenB = new Token(Chain.RINKEBY, '0x0000000000000000000000000000000000000002', 18)
     const pair = new Pair(new TokenAmount(tokenA, '1000'), new TokenAmount(tokenB, '1000'))
 
     const liquidityValue = pair.getLiquidityValue(

--- a/test/pair.test.ts
+++ b/test/pair.test.ts
@@ -1,12 +1,12 @@
-import { ChainId, Token, Pair, TokenAmount, WETH, Price } from '../src'
+import { Chain, Token, Pair, TokenAmount, Price, WETH_RINKEBY, WETH_MAINNET } from '../src'
 
 describe('Pair', () => {
-  const USDC = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
-  const DAI = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
+  const USDC = new Token(Chain.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
+  const DAI = new Token(Chain.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
 
   describe('constructor', () => {
     it('cannot be used for tokens on different chains', () => {
-      expect(() => new Pair(new TokenAmount(USDC, '100'), new TokenAmount(WETH[ChainId.RINKEBY], '100'))).toThrow(
+      expect(() => new Pair(new TokenAmount(USDC, '100'), new TokenAmount(WETH_RINKEBY, '100'))).toThrow(
         'CHAIN_IDS'
       )
     })
@@ -81,7 +81,7 @@ describe('Pair', () => {
     })
 
     it('throws if invalid token', () => {
-      expect(() => pair.priceOf(WETH[ChainId.MAINNET])).toThrow('TOKEN')
+      expect(() => pair.priceOf(WETH_MAINNET)).toThrow('TOKEN')
     })
   })
 
@@ -97,22 +97,22 @@ describe('Pair', () => {
 
     it('throws if not in the pair', () => {
       expect(() =>
-        new Pair(new TokenAmount(DAI, '101'), new TokenAmount(USDC, '100')).reserveOf(WETH[ChainId.MAINNET])
+        new Pair(new TokenAmount(DAI, '101'), new TokenAmount(USDC, '100')).reserveOf(WETH_RINKEBY)
       ).toThrow('TOKEN')
     })
   })
 
   describe('#chainId', () => {
     it('returns the token0 chainId', () => {
-      expect(new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).chainId).toEqual(ChainId.MAINNET)
-      expect(new Pair(new TokenAmount(DAI, '100'), new TokenAmount(USDC, '100')).chainId).toEqual(ChainId.MAINNET)
+      expect(new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).chainId).toEqual(Chain.MAINNET)
+      expect(new Pair(new TokenAmount(DAI, '100'), new TokenAmount(USDC, '100')).chainId).toEqual(Chain.MAINNET)
     })
   })
   describe('#involvesToken', () => {
     expect(new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(USDC)).toEqual(true)
     expect(new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(DAI)).toEqual(true)
     expect(
-      new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(WETH[ChainId.MAINNET])
+      new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(WETH_RINKEBY)
     ).toEqual(false)
   })
 })

--- a/test/pair.test.ts
+++ b/test/pair.test.ts
@@ -6,9 +6,7 @@ describe('Pair', () => {
 
   describe('constructor', () => {
     it('cannot be used for tokens on different chains', () => {
-      expect(() => new Pair(new TokenAmount(USDC, '100'), new TokenAmount(WETH_RINKEBY, '100'))).toThrow(
-        'CHAIN_IDS'
-      )
+      expect(() => new Pair(new TokenAmount(USDC, '100'), new TokenAmount(WETH_RINKEBY, '100'))).toThrow('CHAIN_IDS')
     })
   })
 
@@ -96,9 +94,9 @@ describe('Pair', () => {
     })
 
     it('throws if not in the pair', () => {
-      expect(() =>
-        new Pair(new TokenAmount(DAI, '101'), new TokenAmount(USDC, '100')).reserveOf(WETH_RINKEBY)
-      ).toThrow('TOKEN')
+      expect(() => new Pair(new TokenAmount(DAI, '101'), new TokenAmount(USDC, '100')).reserveOf(WETH_RINKEBY)).toThrow(
+        'TOKEN'
+      )
     })
   })
 
@@ -111,8 +109,8 @@ describe('Pair', () => {
   describe('#involvesToken', () => {
     expect(new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(USDC)).toEqual(true)
     expect(new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(DAI)).toEqual(true)
-    expect(
-      new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(WETH_RINKEBY)
-    ).toEqual(false)
+    expect(new Pair(new TokenAmount(USDC, '100'), new TokenAmount(DAI, '100')).involvesToken(WETH_RINKEBY)).toEqual(
+      false
+    )
   })
 })

--- a/test/route.test.ts
+++ b/test/route.test.ts
@@ -1,9 +1,9 @@
-import { Token, WETH, ChainId, Pair, TokenAmount, Route, ETHER } from '../src'
+import { Token, Chain, Pair, TokenAmount, Route, ETHER, WETH_MAINNET } from '../src'
 
 describe('Route', () => {
-  const token0 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
-  const token1 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000002', 18, 't1')
-  const weth = WETH[ChainId.MAINNET]
+  const token0 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
+  const token1 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000002', 18, 't1')
+  const weth = WETH_MAINNET
   const pair_0_1 = new Pair(new TokenAmount(token0, '100'), new TokenAmount(token1, '200'))
   const pair_0_weth = new Pair(new TokenAmount(token0, '100'), new TokenAmount(weth, '100'))
   const pair_1_weth = new Pair(new TokenAmount(token1, '175'), new TokenAmount(weth, '100'))
@@ -14,7 +14,7 @@ describe('Route', () => {
     expect(route.path).toEqual([token0, token1])
     expect(route.input).toEqual(token0)
     expect(route.output).toEqual(token1)
-    expect(route.chainId).toEqual(ChainId.MAINNET)
+    expect(route.chainId).toEqual(Chain.MAINNET)
   })
 
   it('can have a token as both input and output', () => {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { Chain, CurrencyAmount, ETHER, Pair, Percent, Route, Router, Token, TokenAmount, Trade, WETH, WETH_MAINNET } from '../src'
+import { Chain, CurrencyAmount, ETHER, Pair, Percent, Route, Router, Token, TokenAmount, Trade, WETH_MAINNET } from '../src'
 import JSBI from 'jsbi'
 
 function checkDeadline(deadline: string[] | string): void {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,5 +1,17 @@
 import invariant from 'tiny-invariant'
-import { Chain, CurrencyAmount, ETHER, Pair, Percent, Route, Router, Token, TokenAmount, Trade, WETH_MAINNET } from '../src'
+import {
+  Chain,
+  CurrencyAmount,
+  ETHER,
+  Pair,
+  Percent,
+  Route,
+  Router,
+  Token,
+  TokenAmount,
+  Trade,
+  WETH_MAINNET
+} from '../src'
 import JSBI from 'jsbi'
 
 function checkDeadline(deadline: string[] | string): void {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { ChainId, CurrencyAmount, ETHER, Pair, Percent, Route, Router, Token, TokenAmount, Trade, WETH } from '../src'
+import { Chain, CurrencyAmount, ETHER, Pair, Percent, Route, Router, Token, TokenAmount, Trade, WETH, WETH_MAINNET } from '../src'
 import JSBI from 'jsbi'
 
 function checkDeadline(deadline: string[] | string): void {
@@ -10,12 +10,12 @@ function checkDeadline(deadline: string[] | string): void {
 }
 
 describe('Router', () => {
-  const token0 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
-  const token1 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000002', 18, 't1')
+  const token0 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
+  const token1 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000002', 18, 't1')
 
   const pair_0_1 = new Pair(new TokenAmount(token0, JSBI.BigInt(1000)), new TokenAmount(token1, JSBI.BigInt(1000)))
 
-  const pair_weth_0 = new Pair(new TokenAmount(WETH[ChainId.MAINNET], '1000'), new TokenAmount(token0, '1000'))
+  const pair_weth_0 = new Pair(new TokenAmount(WETH_MAINNET, '1000'), new TokenAmount(token0, '1000'))
 
   describe('#swapCallParameters', () => {
     describe('exact in', () => {
@@ -27,7 +27,7 @@ describe('Router', () => {
         expect(result.methodName).toEqual('swapExactETHForTokens')
         expect(result.args.slice(0, -1)).toEqual([
           '0x51',
-          [WETH[ChainId.MAINNET].address, token0.address, token1.address],
+          [WETH_MAINNET.address, token0.address, token1.address],
           '0x0000000000000000000000000000000000000004'
         ])
         expect(result.value).toEqual('0x64')
@@ -46,7 +46,7 @@ describe('Router', () => {
         expect(result.methodName).toEqual('swapExactETHForTokens')
         expect(result.args).toEqual([
           '0x51',
-          [WETH[ChainId.MAINNET].address, token0.address, token1.address],
+          [WETH_MAINNET.address, token0.address, token1.address],
           '0x0000000000000000000000000000000000000004',
           '0x32'
         ])
@@ -62,7 +62,7 @@ describe('Router', () => {
         expect(result.args.slice(0, -1)).toEqual([
           '0x64',
           '0x51',
-          [token1.address, token0.address, WETH[ChainId.MAINNET].address],
+          [token1.address, token0.address, WETH_MAINNET.address],
           '0x0000000000000000000000000000000000000004'
         ])
         expect(result.value).toEqual('0x0')
@@ -93,7 +93,7 @@ describe('Router', () => {
         expect(result.methodName).toEqual('swapETHForExactTokens')
         expect(result.args.slice(0, -1)).toEqual([
           '0x64',
-          [WETH[ChainId.MAINNET].address, token0.address, token1.address],
+          [WETH_MAINNET.address, token0.address, token1.address],
           '0x0000000000000000000000000000000000000004'
         ])
         expect(result.value).toEqual('0x80')
@@ -108,7 +108,7 @@ describe('Router', () => {
         expect(result.args.slice(0, -1)).toEqual([
           '0x64',
           '0x80',
-          [token1.address, token0.address, WETH[ChainId.MAINNET].address],
+          [token1.address, token0.address, WETH_MAINNET.address],
           '0x0000000000000000000000000000000000000004'
         ])
         expect(result.value).toEqual('0x0')
@@ -145,7 +145,7 @@ describe('Router', () => {
           expect(result.methodName).toEqual('swapExactETHForTokensSupportingFeeOnTransferTokens')
           expect(result.args.slice(0, -1)).toEqual([
             '0x51',
-            [WETH[ChainId.MAINNET].address, token0.address, token1.address],
+            [WETH_MAINNET.address, token0.address, token1.address],
             '0x0000000000000000000000000000000000000004'
           ])
           expect(result.value).toEqual('0x64')
@@ -165,7 +165,7 @@ describe('Router', () => {
           expect(result.args.slice(0, -1)).toEqual([
             '0x64',
             '0x51',
-            [token1.address, token0.address, WETH[ChainId.MAINNET].address],
+            [token1.address, token0.address, WETH_MAINNET.address],
             '0x0000000000000000000000000000000000000004'
           ])
           expect(result.value).toEqual('0x0')

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -6,15 +6,11 @@ describe('Token', () => {
 
   describe('#equals', () => {
     it('fails if address differs', () => {
-      expect(new Token(Chain.MAINNET, ADDRESS_ONE, 18).equals(new Token(Chain.MAINNET, ADDRESS_TWO, 18))).toBe(
-        false
-      )
+      expect(new Token(Chain.MAINNET, ADDRESS_ONE, 18).equals(new Token(Chain.MAINNET, ADDRESS_TWO, 18))).toBe(false)
     })
 
     it('false if chain id differs', () => {
-      expect(new Token(Chain.ROPSTEN, ADDRESS_ONE, 18).equals(new Token(Chain.MAINNET, ADDRESS_ONE, 18))).toBe(
-        false
-      )
+      expect(new Token(Chain.ROPSTEN, ADDRESS_ONE, 18).equals(new Token(Chain.MAINNET, ADDRESS_ONE, 18))).toBe(false)
     })
 
     it('true if only decimals differs', () => {

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -1,4 +1,4 @@
-import { ChainId, Token } from '../src'
+import { Chain, Token } from '../src'
 
 describe('Token', () => {
   const ADDRESS_ONE = '0x0000000000000000000000000000000000000001'
@@ -6,33 +6,33 @@ describe('Token', () => {
 
   describe('#equals', () => {
     it('fails if address differs', () => {
-      expect(new Token(ChainId.MAINNET, ADDRESS_ONE, 18).equals(new Token(ChainId.MAINNET, ADDRESS_TWO, 18))).toBe(
+      expect(new Token(Chain.MAINNET, ADDRESS_ONE, 18).equals(new Token(Chain.MAINNET, ADDRESS_TWO, 18))).toBe(
         false
       )
     })
 
     it('false if chain id differs', () => {
-      expect(new Token(ChainId.ROPSTEN, ADDRESS_ONE, 18).equals(new Token(ChainId.MAINNET, ADDRESS_ONE, 18))).toBe(
+      expect(new Token(Chain.ROPSTEN, ADDRESS_ONE, 18).equals(new Token(Chain.MAINNET, ADDRESS_ONE, 18))).toBe(
         false
       )
     })
 
     it('true if only decimals differs', () => {
-      expect(new Token(ChainId.MAINNET, ADDRESS_ONE, 9).equals(new Token(ChainId.MAINNET, ADDRESS_ONE, 18))).toBe(true)
+      expect(new Token(Chain.MAINNET, ADDRESS_ONE, 9).equals(new Token(Chain.MAINNET, ADDRESS_ONE, 18))).toBe(true)
     })
 
     it('true if address is the same', () => {
-      expect(new Token(ChainId.MAINNET, ADDRESS_ONE, 18).equals(new Token(ChainId.MAINNET, ADDRESS_ONE, 18))).toBe(true)
+      expect(new Token(Chain.MAINNET, ADDRESS_ONE, 18).equals(new Token(Chain.MAINNET, ADDRESS_ONE, 18))).toBe(true)
     })
 
     it('true on reference equality', () => {
-      const token = new Token(ChainId.MAINNET, ADDRESS_ONE, 18)
+      const token = new Token(Chain.MAINNET, ADDRESS_ONE, 18)
       expect(token.equals(token)).toBe(true)
     })
 
     it('true even if name/symbol/decimals differ', () => {
-      const tokenA = new Token(ChainId.MAINNET, ADDRESS_ONE, 9, 'abc', 'def')
-      const tokenB = new Token(ChainId.MAINNET, ADDRESS_ONE, 18, 'ghi', 'jkl')
+      const tokenA = new Token(Chain.MAINNET, ADDRESS_ONE, 9, 'abc', 'def')
+      const tokenB = new Token(Chain.MAINNET, ADDRESS_ONE, 18, 'ghi', 'jkl')
       expect(tokenA.equals(tokenB)).toBe(true)
     })
   })

--- a/test/trade.test.ts
+++ b/test/trade.test.ts
@@ -10,7 +10,6 @@ import {
   TokenAmount,
   Trade,
   TradeType,
-  WETH,
   WETH_MAINNET
 } from '../src'
 

--- a/test/trade.test.ts
+++ b/test/trade.test.ts
@@ -26,7 +26,7 @@ describe('Trade', () => {
   const pair_1_3 = new Pair(new TokenAmount(token1, JSBI.BigInt(1200)), new TokenAmount(token3, JSBI.BigInt(1300)))
 
   const pair_weth_0 = new Pair(
-    new TokenAmount(WETH_MAINNET , JSBI.BigInt(1000)),
+    new TokenAmount(WETH_MAINNET, JSBI.BigInt(1000)),
     new TokenAmount(token0, JSBI.BigInt(1000))
   )
 

--- a/test/trade.test.ts
+++ b/test/trade.test.ts
@@ -1,6 +1,6 @@
 import JSBI from 'jsbi'
 import {
-  ChainId,
+  Chain,
   ETHER,
   CurrencyAmount,
   Pair,
@@ -10,14 +10,15 @@ import {
   TokenAmount,
   Trade,
   TradeType,
-  WETH
+  WETH,
+  WETH_MAINNET
 } from '../src'
 
 describe('Trade', () => {
-  const token0 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
-  const token1 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000002', 18, 't1')
-  const token2 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000003', 18, 't2')
-  const token3 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000004', 18, 't3')
+  const token0 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
+  const token1 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000002', 18, 't1')
+  const token2 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000003', 18, 't2')
+  const token3 = new Token(Chain.MAINNET, '0x0000000000000000000000000000000000000004', 18, 't3')
 
   const pair_0_1 = new Pair(new TokenAmount(token0, JSBI.BigInt(1000)), new TokenAmount(token1, JSBI.BigInt(1000)))
   const pair_0_2 = new Pair(new TokenAmount(token0, JSBI.BigInt(1000)), new TokenAmount(token2, JSBI.BigInt(1100)))
@@ -26,7 +27,7 @@ describe('Trade', () => {
   const pair_1_3 = new Pair(new TokenAmount(token1, JSBI.BigInt(1200)), new TokenAmount(token3, JSBI.BigInt(1300)))
 
   const pair_weth_0 = new Pair(
-    new TokenAmount(WETH[ChainId.MAINNET], JSBI.BigInt(1000)),
+    new TokenAmount(WETH_MAINNET , JSBI.BigInt(1000)),
     new TokenAmount(token0, JSBI.BigInt(1000))
   )
 
@@ -155,10 +156,10 @@ describe('Trade', () => {
       )
       expect(result).toHaveLength(2)
       expect(result[0].inputAmount.currency).toEqual(ETHER)
-      expect(result[0].route.path).toEqual([WETH[ChainId.MAINNET], token0, token1, token3])
+      expect(result[0].route.path).toEqual([WETH_MAINNET, token0, token1, token3])
       expect(result[0].outputAmount.currency).toEqual(token3)
       expect(result[1].inputAmount.currency).toEqual(ETHER)
-      expect(result[1].route.path).toEqual([WETH[ChainId.MAINNET], token0, token3])
+      expect(result[1].route.path).toEqual([WETH_MAINNET, token0, token3])
       expect(result[1].outputAmount.currency).toEqual(token3)
     })
     it('works for ETHER currency output', () => {
@@ -169,10 +170,10 @@ describe('Trade', () => {
       )
       expect(result).toHaveLength(2)
       expect(result[0].inputAmount.currency).toEqual(token3)
-      expect(result[0].route.path).toEqual([token3, token0, WETH[ChainId.MAINNET]])
+      expect(result[0].route.path).toEqual([token3, token0, WETH_MAINNET])
       expect(result[0].outputAmount.currency).toEqual(ETHER)
       expect(result[1].inputAmount.currency).toEqual(token3)
-      expect(result[1].route.path).toEqual([token3, token1, token0, WETH[ChainId.MAINNET]])
+      expect(result[1].route.path).toEqual([token3, token1, token0, WETH_MAINNET])
       expect(result[1].outputAmount.currency).toEqual(ETHER)
     })
   })
@@ -380,10 +381,10 @@ describe('Trade', () => {
       )
       expect(result).toHaveLength(2)
       expect(result[0].inputAmount.currency).toEqual(ETHER)
-      expect(result[0].route.path).toEqual([WETH[ChainId.MAINNET], token0, token1, token3])
+      expect(result[0].route.path).toEqual([WETH_MAINNET, token0, token1, token3])
       expect(result[0].outputAmount.currency).toEqual(token3)
       expect(result[1].inputAmount.currency).toEqual(ETHER)
-      expect(result[1].route.path).toEqual([WETH[ChainId.MAINNET], token0, token3])
+      expect(result[1].route.path).toEqual([WETH_MAINNET, token0, token3])
       expect(result[1].outputAmount.currency).toEqual(token3)
     })
     it('works for ETHER currency output', () => {
@@ -394,10 +395,10 @@ describe('Trade', () => {
       )
       expect(result).toHaveLength(2)
       expect(result[0].inputAmount.currency).toEqual(token3)
-      expect(result[0].route.path).toEqual([token3, token0, WETH[ChainId.MAINNET]])
+      expect(result[0].route.path).toEqual([token3, token0, WETH_MAINNET])
       expect(result[0].outputAmount.currency).toEqual(ETHER)
       expect(result[1].inputAmount.currency).toEqual(token3)
-      expect(result[1].route.path).toEqual([token3, token1, token0, WETH[ChainId.MAINNET]])
+      expect(result[1].route.path).toEqual([token3, token1, token0, WETH_MAINNET])
       expect(result[1].outputAmount.currency).toEqual(ETHER)
     })
   })


### PR DESCRIPTION
Closes #52. 

This PR generalize the type `ChainId`, adding support for any network. Also adds xDAI as a `Chain` (enum)

As suggested in #53 by @moodysalem , I took a more generalist approach to support any network.

Basically, now ChainId is a `number` (a `ChainId | number` in TS becomes `number` since one is a subset of the other). It also makes sense to model the `chainId` as a number.

The enum with some convenient known chains it's now called `Chain`.
I had to adapt in several places the use of the enum (i.e. `ChainId.MAINNET ---> Chain.MAINNET`)


```ts
export enum Chain {
  MAINNET = 1,
  ROPSTEN = 3,
  ...
}	

export type ChainId = number
```


Also `WETH` is typed as `Partial<Record<ChainId, Token>>`, so we might find networks where we don't know the WETH contract. That's good, because reflects reality, there's even networks where WETH is not used (xDAI has "Wrapped xDAI" not WETH). I needed to account in a few places.

```ts
export const WETH: Partial<Record<ChainId, Token>> = {  
  [Chain.MAINNET]: WETH_MAINNET,
  [Chain.ROPSTEN]: WETH_ROPSTEN,
   ...
}
``` 

