### PR TITLE
Upgrade Yarn, add more lifecycle scripts, remove build output from tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "tsdx build",
     "start": "tsdx watch",
     "test": "tsdx test",
-    "prepublishOnly": "tsdx build"
+    "prepare": "tsdx build"
   },
   "dependencies": {
     "@ethersproject/address": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uniswap/v2-sdk",
+  "name": "@zuzu-cat/defira-sdk",
   "license": "MIT",
   "version": "3.0.1",
   "description": "🛠 An SDK for building applications on top of Uniswap V2",
@@ -8,10 +8,11 @@
   "files": [
     "dist"
   ],
-  "repository": "https://github.com/Uniswap/uniswap-v2-sdk.git",
+  "repository": "https://github.com/zuzu-cat/defira-sdk.git",
   "keywords": [
-    "uniswap",
-    "ethereum"
+    "defira",
+    "harmony",
+    "uniswap"
   ],
   "module": "dist/v2-sdk.esm.js",
   "scripts": {


### PR DESCRIPTION
* Upgrade repo to use Yarn 2
* Add more lifecycle scripts to be fully compatible with both [Yarn](https://docs.npmjs.com/cli/v8/using-npm/scripts) and [NPM](https://docs.npmjs.com/cli/v8/using-npm/scripts)
* Add lint and test steps to prepublish
* Remove build outputs from index since scripts should now be correct