### PR TITLE
Add `jsbi` explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@ethersproject/address": "^5.0.0",
     "@ethersproject/solidity": "^5.0.0",
     "@uniswap/sdk-core": "^3.0.0-alpha.3",
+    "jsbi": "^3.1.4",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },


### PR DESCRIPTION
# Issue

- `jsbi@^3.1.4` dependency is used in the package without being defined as an explicit dependency in `package.json`

This impacts developers using this package as dependency resolvers (such as `npm` or `yarn`) won't automatically install missing dependencies, or will install it with incorrect (and thus perhaps incompatible) versions

# Fix

- This PR adds the missing dependencies to `package.json` without impacting the current state of `yarn.lock`