### PR TITLE
v2 quote with fee-on-transfer tax considerations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ethersproject/address": "^5.0.0",
     "@ethersproject/solidity": "^5.0.0",
-    "@uniswap/sdk-core": "^4.0.2",
+    "@uniswap/sdk-core": "^4.0.7",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
+import {Percent } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
-import { Fraction } from '@uniswap/sdk-core'
 
 export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
 
@@ -13,7 +13,7 @@ export const ONE = JSBI.BigInt(1)
 export const FIVE = JSBI.BigInt(5)
 export const _997 = JSBI.BigInt(997)
 export const _1000 = JSBI.BigInt(1000)
-export const _10000 = JSBI.BigInt(10000)
+export const BASIS_POINTS = JSBI.BigInt(10000)
 
-export const ZERO_FRACTION = new Fraction(ZERO, ONE)
-export const ONE_FRACTION = new Fraction(ONE)
+export const ZERO_PERCENT = new Percent(ZERO)
+export const ONE_HUNDRED_PERCENT = new Percent(ONE)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,3 +16,4 @@ export const _1000 = JSBI.BigInt(1000)
 export const _10000 = JSBI.BigInt(10000)
 
 export const ZERO_FRACTION = new Fraction(ZERO, ONE)
+export const ONE_FRACTION = new Fraction(ONE)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import JSBI from 'jsbi'
+import {Fraction} from "@uniswap/sdk-core";
 
 export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
 
@@ -12,3 +13,6 @@ export const ONE = JSBI.BigInt(1)
 export const FIVE = JSBI.BigInt(5)
 export const _997 = JSBI.BigInt(997)
 export const _1000 = JSBI.BigInt(1000)
+export const _10000 = JSBI.BigInt(10000)
+
+export const ZERO_FRACTION = new Fraction(ZERO, ONE)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 import JSBI from 'jsbi'
-import {Fraction} from "@uniswap/sdk-core";
+import { Fraction } from '@uniswap/sdk-core'
 
 export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import {Percent } from '@uniswap/sdk-core'
+import { Percent } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 
 export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -229,7 +229,7 @@ describe('Pair', () => {
         //                     = 94 * 0.96
         //                     = 90.24
         //                     = 90 (rounded down)
-        const expectedOutputBlastAmount = "0.00000000000000009"
+        const expectedOutputBlastAmount = '0.00000000000000009'
         expect(outputBlastAmount.toExact()).toEqual(expectedOutputBlastAmount)
       })
 
@@ -269,7 +269,7 @@ describe('Pair', () => {
         //                     = 100.518134715 + 1
         //                     = 100 (rounded down) + 1
         //                     = 101
-        const expectedInputBlasterAmount = "0.000000101"
+        const expectedInputBlasterAmount = '0.000000101'
         expect(inputBlasterAmount.toExact()).toEqual(expectedInputBlasterAmount)
       })
     })

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -1,8 +1,8 @@
-import {ChainId, CurrencyAmount, Price, Token, WETH9} from '@uniswap/sdk-core'
-import {InsufficientInputAmountError} from '../errors'
-import {computePairAddress, Pair} from './pair'
-import {BigNumber} from "@ethersproject/bignumber";
-import JSBI from "jsbi";
+import { ChainId, CurrencyAmount, Price, Token, WETH9 } from '@uniswap/sdk-core'
+import { InsufficientInputAmountError } from '../errors'
+import { computePairAddress, Pair } from './pair'
+import { BigNumber } from '@ethersproject/bignumber'
+import JSBI from 'jsbi'
 
 describe('computePairAddress', () => {
   it('should correctly compute the pool address', () => {
@@ -178,25 +178,27 @@ describe('Pair', () => {
     const BLASTBuyFeeBps = BigNumber.from(400)
     const BLASTSellFeeBps = BigNumber.from(10000)
     const BLAST = new Token(
-        ChainId.MAINNET,
-        '0x3ed643e9032230f01c6c36060e305ab53ad3b482',
-        18,
-        'BLAST',
-        'BLAST',
-        false,
-        BLASTBuyFeeBps,
-        BLASTSellFeeBps)
+      ChainId.MAINNET,
+      '0x3ed643e9032230f01c6c36060e305ab53ad3b482',
+      18,
+      'BLAST',
+      'BLAST',
+      false,
+      BLASTBuyFeeBps,
+      BLASTSellFeeBps
+    )
     const BLASTERSBuyFeeBps = BigNumber.from(300)
     const BLASTERSSellFeeBps = BigNumber.from(350)
     const BLASTERS = new Token(
-        ChainId.MAINNET,
-        '0xab98093C7232E98A47D7270CE0c1c2106f61C73b',
-        9,
-        'BLAST',
-        'BLASTERS',
-        false,
-        BLASTERSBuyFeeBps,
-        BLASTERSSellFeeBps)
+      ChainId.MAINNET,
+      '0xab98093C7232E98A47D7270CE0c1c2106f61C73b',
+      9,
+      'BLAST',
+      'BLASTERS',
+      false,
+      BLASTERSBuyFeeBps,
+      BLASTERSSellFeeBps
+    )
 
     describe('getOutputAmount', () => {
       it('getOutputAmount for input token BLASTERS and output token BLAST', () => {
@@ -380,4 +382,3 @@ describe('Pair', () => {
     })
   })
 })
-

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -217,19 +217,20 @@ describe('Pair', () => {
         // However in practice, we have round down of precisions in multiple steps
         // hence the amount out will be slightly less than 91.48:
         //
-        // inputAmountWithFee = 100 * 997 = 99700
+        // inputAmount = 100
         // percentAfterSellFeesInDecimal = fraction(9650, 10000)
-        // inputAmountWithFeeAndTax = fraction(9650, 10000) * 99700 = 96210.5 = 96210 (rounded down)
-        // numerator = 96210 * 10000 = 962100000
-        // denominator = 10000 * 1000 + 96210 = 10096210
-        // outputAmount = 962100000 / 10096210 = 95 (rounded down)
+        // inputAmountAfterTax = 100 * fraction(9650, 10000) = 96.5 = 96 (rounded down)
+        // inputAmountWithFeeAndAfterTax = 96 * 997 = 95712
+        // numerator = 95712 * 10000 = 957120000
+        // denominator = 10000 * 1000 + 95712 = 10095712
+        // outputAmount = 957120000 / 10095712 = 94.8046061536 = 94 (rounded down)
         // buyFeePercentInDecimal = fraction(400, 10000)
         // percentAfterBuyFeesInDecimal = fraction(9600, 10000)
-        // outputAmountWithTax = 95 * fraction(9600, 10000)
-        //                     = 95 * 0.96
-        //                     = 91.2
-        //                     = 91 (rounded down)
-        const expectedOutputBlastAmount = JSBI.BigInt(91)
+        // outputAmountAfterTax = 94 * fraction(9600, 10000)
+        //                     = 94 * 0.96
+        //                     = 90.24
+        //                     = 90 (rounded down)
+        const expectedOutputBlastAmount = JSBI.BigInt(90)
         expect(outputBlastAmount.quotient).toEqual(expectedOutputBlastAmount)
       })
 
@@ -251,7 +252,7 @@ describe('Pair', () => {
         //
         // buyFeePercentInDecimal = fraction(400, 10000)
         // percentAfterBuyFeesInDecimal = 1 - fraction(400, 10000) = fraction(9600, 10000)
-        // outputAmountWithTax = 91 / fraction(960000, 10000) + 1
+        // outputAmountBeforeTax = 91 / fraction(960000, 10000) + 1
         //                     = 91 / 0.96 + 1
         //                     = 94.7916666667 + 1
         //                     = 94 (rounded down) + 1
@@ -264,7 +265,7 @@ describe('Pair', () => {
         //             = 97 (rounded up)
         // sellFeePercentInDecimal = fraction(350, 10000)
         // percentAfterSellFeesInDecimal = 1 - fraction(350, 10000) = fraction(9650, 10000)
-        // inputAmountWithTax = (97 / fraction(9650, 10000)) + 1
+        // inputAmountBeforeTax = (97 / fraction(9650, 10000)) + 1
         //                     = (97 / 0.965) + 1
         //                     = 100.518134715 + 1
         //                     = 100 (rounded down) + 1

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -2,7 +2,6 @@ import { ChainId, CurrencyAmount, Price, Token, WETH9 } from '@uniswap/sdk-core'
 import { InsufficientInputAmountError } from '../errors'
 import { computePairAddress, Pair } from './pair'
 import { BigNumber } from '@ethersproject/bignumber'
-import JSBI from 'jsbi'
 
 describe('computePairAddress', () => {
   it('should correctly compute the pool address', () => {
@@ -230,8 +229,8 @@ describe('Pair', () => {
         //                     = 94 * 0.96
         //                     = 90.24
         //                     = 90 (rounded down)
-        const expectedOutputBlastAmount = JSBI.BigInt(90)
-        expect(outputBlastAmount.quotient).toEqual(expectedOutputBlastAmount)
+        const expectedOutputBlastAmount = "0.00000000000000009"
+        expect(outputBlastAmount.toExact()).toEqual(expectedOutputBlastAmount)
       })
 
       it('getInputAmount for input token BLASTERS and output token BLAST', () => {
@@ -270,8 +269,8 @@ describe('Pair', () => {
         //                     = 100.518134715 + 1
         //                     = 100 (rounded down) + 1
         //                     = 101
-        const expectedInputBlasterAmount = JSBI.BigInt(101)
-        expect(inputBlasterAmount.quotient).toEqual(expectedInputBlasterAmount)
+        const expectedInputBlasterAmount = "0.000000101"
+        expect(inputBlasterAmount.toExact()).toEqual(expectedInputBlasterAmount)
       })
     })
   })

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -216,16 +216,16 @@ describe('Pair', () => {
         // hence the amount out will be slightly less than 91.48:
         //
         // inputAmountWithFee = 100 * 997 = 99700
-        // sellFeePercentInDecimal = fraction(350, 10000)
-        // taxAmount = fraction(34895000, 10000)
-        // inputAmountWithFeeAndTax = (99700 - fraction(34895000, 10000)).quotient = 96210 (rounded down)
+        // percentAfterSellFeesInDecimal = fraction(9650, 10000)
+        // inputAmountWithFeeAndTax = fraction(9650, 10000) * 99700 = 96210.5 = 96210 (rounded down)
         // numerator = 96210 * 10000 = 962100000
         // denominator = 10000 * 1000 + 96210 = 10096210
         // outputAmount = 962100000 / 10096210 = 95 (rounded down)
         // buyFeePercentInDecimal = fraction(400, 10000)
-        // taxAmount = fraction(38000, 10000)
-        // outputAmountWithTax = (95 - fraction(38000, 10000)).quotient
-        //                     = (95 - 3.8).quotient
+        // percentAfterBuyFeesInDecimal = fraction(9600, 10000)
+        // outputAmountWithTax = 95 * fraction(9600, 10000)
+        //                     = 95 * 0.96
+        //                     = 91.2
         //                     = 91 (rounded down)
         const expectedOutputBlastAmount = JSBI.BigInt(91)
         expect(outputBlastAmount.quotient).toEqual(expectedOutputBlastAmount)
@@ -244,21 +244,30 @@ describe('Pair', () => {
         // 10000 * 100 * (1 - 4%) * 1000 / ((10000 - 100 * (1 - 4%)) * 997) / (1 - 3.5%)
         // = 100.7483934892
         //
-        // However in practice, we have round down of precisions in multiple steps
-        // hence the amount out will be slightly less than 100.7483934892:
+        // However in practice, we have round up of precisions in multiple steps
+        // hence the amount out will be slightly more than 100.7483934892:
         //
         // buyFeePercentInDecimal = fraction(400, 10000)
-        // taxAmount = fraction(40000, 10000)
-        // outputAmountWithTax = 91 + fraction(40000, 10000) = 95
+        // percentAfterBuyFeesInDecimal = 1 - fraction(400, 10000) = fraction(9600, 10000)
+        // outputAmountWithTax = 91 / fraction(960000, 10000) + 1
+        //                     = 91 / 0.96 + 1
+        //                     = 94.7916666667 + 1
+        //                     = 94 (rounded down) + 1
+        //                     = 95 (rounded up)
         // numerator = 10000 * 95 * 1000 = 950000000
         // denominator = (10000 - 95) * 997 = 9875285
-        // inputAmount = 950000000 / 9875285 = 96 (rounded down)
+        // inputAmount = 950000000 / 9875285 + 1
+        //             = 96.1997552476 + 1
+        //             = 96 (rounded down) + 1
+        //             = 97 (rounded up)
         // sellFeePercentInDecimal = fraction(350, 10000)
-        // taxAmount = fraction(33950, 10000)
-        // inputAmountWithTax = (96 + fraction(33950, 10000)).quotient
-        //                     = (96 + 3.395).quotient
-        //                     = 99 (rounded down)
-        const expectedInputBlasterAmount = JSBI.BigInt(99)
+        // percentAfterSellFeesInDecimal = 1 - fraction(350, 10000) = fraction(9650, 10000)
+        // inputAmountWithTax = (97 / fraction(9650, 10000)) + 1
+        //                     = (97 / 0.965) + 1
+        //                     = 100.518134715 + 1
+        //                     = 100 (rounded down) + 1
+        //                     = 101
+        const expectedInputBlasterAmount = JSBI.BigInt(101)
         expect(inputBlasterAmount.quotient).toEqual(expectedInputBlasterAmount)
       })
     })

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -171,7 +171,8 @@ export class Pair {
     const inputAmountWithFee = JSBI.multiply(inputAmount.quotient, _997)
 
     const inputAmountWithFeeAndTax = this.deriveInputAmountWithTax(
-        CurrencyAmount.fromRawAmount(inputAmount.currency, inputAmountWithFee));
+      CurrencyAmount.fromRawAmount(inputAmount.currency, inputAmountWithFee)
+    )
 
     const numerator = JSBI.multiply(inputAmountWithFeeAndTax.quotient, outputReserve.quotient)
     const denominator = JSBI.add(JSBI.multiply(inputReserve.quotient, _1000), inputAmountWithFeeAndTax.quotient)
@@ -327,10 +328,7 @@ export class Pair {
     if (sellFeeBips) {
       const sellFeePercentInDecimal = JSBI.divide(JSBI.BigInt(inputAmount.currency.sellFeeBps), JSBI.BigInt(10000))
       const taxAmount = JSBI.multiply(inputAmount.quotient, sellFeePercentInDecimal)
-      return CurrencyAmount.fromRawAmount(
-          inputAmount.currency,
-          JSBI.subtract(inputAmount.quotient, taxAmount)
-      );
+      return CurrencyAmount.fromRawAmount(inputAmount.currency, JSBI.subtract(inputAmount.quotient, taxAmount))
     } else {
       return inputAmount
     }
@@ -341,10 +339,7 @@ export class Pair {
     if (buyFeeBps) {
       const buyFeePercentInDecimal = JSBI.divide(JSBI.BigInt(outputAmount.currency.buyFeeBps), JSBI.BigInt(10000))
       const taxAmount = JSBI.multiply(outputAmount.quotient, buyFeePercentInDecimal)
-      return CurrencyAmount.fromRawAmount(
-          outputAmount.currency,
-          JSBI.subtract(outputAmount.quotient, taxAmount)
-      )
+      return CurrencyAmount.fromRawAmount(outputAmount.currency, JSBI.subtract(outputAmount.quotient, taxAmount))
     } else {
       return outputAmount
     }

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -14,7 +14,9 @@ import {
   _1000,
   ONE,
   ZERO,
-  BASIS_POINTS, ONE_HUNDRED_PERCENT, ZERO_PERCENT
+  BASIS_POINTS,
+  ONE_HUNDRED_PERCENT,
+  ZERO_PERCENT
 } from '../constants'
 import { InsufficientReservesError, InsufficientInputAmountError } from '../errors'
 
@@ -185,11 +187,12 @@ export class Pair {
     const outputReserve = this.reserveOf(inputAmount.currency.equals(this.token0) ? this.token1 : this.token0)
 
     const percentAfterSellFees = this.derivePercentAfterSellFees(inputAmount)
-    const inputAmountAfterTax = percentAfterSellFees.greaterThan(ZERO_PERCENT) ?
-        CurrencyAmount.fromRawAmount(
-            inputAmount.currency,
-            percentAfterSellFees.multiply(inputAmount).quotient   // fraction.quotient will round down by itself, which is desired
-        ) : inputAmount;
+    const inputAmountAfterTax = percentAfterSellFees.greaterThan(ZERO_PERCENT)
+      ? CurrencyAmount.fromRawAmount(
+          inputAmount.currency,
+          percentAfterSellFees.multiply(inputAmount).quotient // fraction.quotient will round down by itself, which is desired
+        )
+      : inputAmount
 
     const inputAmountWithFeeAndAfterTax = JSBI.multiply(inputAmountAfterTax.quotient, _997)
     const numerator = JSBI.multiply(inputAmountWithFeeAndAfterTax, outputReserve.quotient)
@@ -204,16 +207,20 @@ export class Pair {
     }
 
     const percentAfterBuyFees = this.derivePercentAfterBuyFees(outputAmount)
-    const outputAmountAfterTax =  percentAfterBuyFees.greaterThan(ZERO_PERCENT) ?
-        CurrencyAmount.fromRawAmount(
+    const outputAmountAfterTax = percentAfterBuyFees.greaterThan(ZERO_PERCENT)
+      ? CurrencyAmount.fromRawAmount(
           outputAmount.currency,
           outputAmount.multiply(percentAfterBuyFees).quotient // fraction.quotient will round down by itself, which is desired
-        ) : outputAmount;
+        )
+      : outputAmount
     if (JSBI.equal(outputAmountAfterTax.quotient, ZERO)) {
       throw new InsufficientInputAmountError()
     }
 
-    return [outputAmountAfterTax, new Pair(inputReserve.add(inputAmountAfterTax), outputReserve.subtract(outputAmountAfterTax))]
+    return [
+      outputAmountAfterTax,
+      new Pair(inputReserve.add(inputAmountAfterTax), outputReserve.subtract(outputAmountAfterTax))
+    ]
   }
 
   /**
@@ -261,11 +268,12 @@ export class Pair {
   public getInputAmount(outputAmount: CurrencyAmount<Token>): [CurrencyAmount<Token>, Pair] {
     invariant(this.involvesToken(outputAmount.currency), 'TOKEN')
     const percentAfterBuyFees = this.derivePercentAfterBuyFees(outputAmount)
-    const outputAmountBeforeTax = percentAfterBuyFees.greaterThan(ZERO_PERCENT) ?
-        CurrencyAmount.fromRawAmount(
+    const outputAmountBeforeTax = percentAfterBuyFees.greaterThan(ZERO_PERCENT)
+      ? CurrencyAmount.fromRawAmount(
           outputAmount.currency,
           JSBI.add(outputAmount.divide(percentAfterBuyFees).quotient, ONE) // add 1 for rounding up
-        ) : outputAmount;
+        )
+      : outputAmount
 
     if (
       JSBI.equal(this.reserve0.quotient, ZERO) ||
@@ -287,11 +295,12 @@ export class Pair {
     )
 
     const percentAfterSellFees = this.derivePercentAfterSellFees(inputAmount)
-    const inputAmountBeforeTax = percentAfterSellFees.greaterThan(ZERO_PERCENT) ?
-        CurrencyAmount.fromRawAmount(
+    const inputAmountBeforeTax = percentAfterSellFees.greaterThan(ZERO_PERCENT)
+      ? CurrencyAmount.fromRawAmount(
           inputAmount.currency,
           JSBI.add(inputAmount.divide(percentAfterSellFees).quotient, ONE) // add 1 for rounding up
-        ) : inputAmount;
+        )
+      : inputAmount
     return [inputAmountBeforeTax, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount))]
   }
 

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -1,4 +1,4 @@
-import {BigintIsh, Price, sqrt, Token, CurrencyAmount, Fraction} from '@uniswap/sdk-core'
+import { BigintIsh, Price, sqrt, Token, CurrencyAmount, Fraction } from '@uniswap/sdk-core'
 import invariant from 'tiny-invariant'
 import JSBI from 'jsbi'
 import { pack, keccak256 } from '@ethersproject/solidity'
@@ -15,7 +15,8 @@ import {
   ONE,
   ZERO,
   _10000,
-  ZERO_FRACTION, ONE_FRACTION
+  ZERO_FRACTION,
+  ONE_FRACTION
 } from '../constants'
 import { InsufficientReservesError, InsufficientInputAmountError } from '../errors'
 
@@ -183,10 +184,12 @@ export class Pair {
     const outputReserve = this.reserveOf(inputAmount.currency.equals(this.token0) ? this.token1 : this.token0)
     const inputAmountWithFee = JSBI.multiply(inputAmount.quotient, _997)
 
-    const percentAfterSellFeesInDecimal = this.derivePercentAfterSellFeesInDecimal(CurrencyAmount.fromRawAmount(inputAmount.currency, inputAmountWithFee))
-    const inputAmountWithFeeAndTax = (percentAfterSellFeesInDecimal.greaterThan(ZERO)) ?
-            percentAfterSellFeesInDecimal.multiply(inputAmountWithFee).quotient // fraction.quotient will round down by itself, which is desired
-            : inputAmountWithFee
+    const percentAfterSellFeesInDecimal = this.derivePercentAfterSellFeesInDecimal(
+      CurrencyAmount.fromRawAmount(inputAmount.currency, inputAmountWithFee)
+    )
+    const inputAmountWithFeeAndTax = percentAfterSellFeesInDecimal.greaterThan(ZERO)
+      ? percentAfterSellFeesInDecimal.multiply(inputAmountWithFee).quotient // fraction.quotient will round down by itself, which is desired
+      : inputAmountWithFee
 
     const numerator = JSBI.multiply(inputAmountWithFeeAndTax, outputReserve.quotient)
     const denominator = JSBI.add(JSBI.multiply(inputReserve.quotient, _1000), inputAmountWithFeeAndTax)
@@ -200,11 +203,12 @@ export class Pair {
     }
 
     const percentAfterBuyFeesInDecimal = this.derivePercentAfterBuyFeesInDecimal(outputAmount)
-    const outputAmountWithTax = percentAfterBuyFeesInDecimal.greaterThan(ZERO) ?
-        CurrencyAmount.fromRawAmount(
-            outputAmount.currency,
-            outputAmount.multiply(percentAfterBuyFeesInDecimal).quotient // fraction.quotient will round down by itself, which is desired
-        ) : outputAmount
+    const outputAmountWithTax = percentAfterBuyFeesInDecimal.greaterThan(ZERO)
+      ? CurrencyAmount.fromRawAmount(
+          outputAmount.currency,
+          outputAmount.multiply(percentAfterBuyFeesInDecimal).quotient // fraction.quotient will round down by itself, which is desired
+        )
+      : outputAmount
     if (JSBI.equal(outputAmountWithTax.quotient, ZERO)) {
       throw new InsufficientInputAmountError()
     }
@@ -257,10 +261,12 @@ export class Pair {
   public getInputAmount(outputAmount: CurrencyAmount<Token>): [CurrencyAmount<Token>, Pair] {
     invariant(this.involvesToken(outputAmount.currency), 'TOKEN')
     const percentAfterBuyFeesInDecimal = this.derivePercentAfterBuyFeesInDecimal(outputAmount)
-    const outputAmountWithTax = percentAfterBuyFeesInDecimal.greaterThan(ZERO) ? CurrencyAmount.fromRawAmount(
-        outputAmount.currency,
-        JSBI.add(outputAmount.divide(percentAfterBuyFeesInDecimal).quotient, ONE) // add 1 for rounding up
-    ) : outputAmount
+    const outputAmountWithTax = percentAfterBuyFeesInDecimal.greaterThan(ZERO)
+      ? CurrencyAmount.fromRawAmount(
+          outputAmount.currency,
+          JSBI.add(outputAmount.divide(percentAfterBuyFeesInDecimal).quotient, ONE) // add 1 for rounding up
+        )
+      : outputAmount
 
     if (
       JSBI.equal(this.reserve0.quotient, ZERO) ||
@@ -282,11 +288,12 @@ export class Pair {
     )
 
     const percentAfterSellFeesInDecimal = this.derivePercentAfterSellFeesInDecimal(inputAmount)
-    const inputAmountWithTax = (percentAfterSellFeesInDecimal.greaterThan(ZERO)) ?
-        CurrencyAmount.fromRawAmount(
-            inputAmount.currency,
-            JSBI.add(inputAmount.divide(percentAfterSellFeesInDecimal).quotient, ONE) // add 1 for rounding up
-        ) : inputAmount
+    const inputAmountWithTax = percentAfterSellFeesInDecimal.greaterThan(ZERO)
+      ? CurrencyAmount.fromRawAmount(
+          inputAmount.currency,
+          JSBI.add(inputAmount.divide(percentAfterSellFeesInDecimal).quotient, ONE) // add 1 for rounding up
+        )
+      : inputAmount
     return [inputAmountWithTax, new Pair(inputReserve.add(inputAmount), outputReserve.subtract(outputAmount))]
   }
 

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -160,7 +160,7 @@ export class Pair {
    * outputAmountWithTax = (B * 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn
    *                       /
    *                       (A + 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn)
- *                       = (B * 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn * 1000
+   *                       = (B * 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn * 1000
    *                       /
    *                       ((A + 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn) * 1000)
    *                     = (B * (1 - amountIn.sellFeesBips / 10000) 997 * * amountIn

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -3,6 +3,7 @@ import invariant from 'tiny-invariant'
 import JSBI from 'jsbi'
 import { pack, keccak256 } from '@ethersproject/solidity'
 import { getCreate2Address } from '@ethersproject/address'
+import { BigNumber } from '@ethersproject/bignumber'
 
 import { FACTORY_ADDRESS, INIT_CODE_HASH, MINIMUM_LIQUIDITY, FIVE, _997, _1000, ONE, ZERO } from '../constants'
 import { InsufficientReservesError, InsufficientInputAmountError } from '../errors'
@@ -325,8 +326,8 @@ export class Pair {
 
   private deriveInputAmountWithTax(inputAmount: CurrencyAmount<Token>): CurrencyAmount<Token> {
     const sellFeeBips = inputAmount.currency.sellFeeBps
-    if (sellFeeBips) {
-      const sellFeePercentInDecimal = JSBI.divide(JSBI.BigInt(inputAmount.currency.sellFeeBps), JSBI.BigInt(10000))
+    if (sellFeeBips?.gt(BigNumber.from(0))) {
+      const sellFeePercentInDecimal = JSBI.divide(JSBI.BigInt(sellFeeBips), JSBI.BigInt(10000))
       const taxAmount = JSBI.multiply(inputAmount.quotient, sellFeePercentInDecimal)
       return CurrencyAmount.fromRawAmount(inputAmount.currency, JSBI.subtract(inputAmount.quotient, taxAmount))
     } else {
@@ -336,8 +337,8 @@ export class Pair {
 
   private deriveOutputAmountWithTax(outputAmount: CurrencyAmount<Token>): CurrencyAmount<Token> {
     const buyFeeBps = outputAmount.currency.buyFeeBps
-    if (buyFeeBps) {
-      const buyFeePercentInDecimal = JSBI.divide(JSBI.BigInt(outputAmount.currency.buyFeeBps), JSBI.BigInt(10000))
+    if (buyFeeBps?.gt(BigNumber.from(0))) {
+      const buyFeePercentInDecimal = JSBI.divide(JSBI.BigInt(buyFeeBps), JSBI.BigInt(10000))
       const taxAmount = JSBI.multiply(outputAmount.quotient, buyFeePercentInDecimal)
       return CurrencyAmount.fromRawAmount(outputAmount.currency, JSBI.subtract(outputAmount.quotient, taxAmount))
     } else {

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -160,9 +160,12 @@ export class Pair {
    * outputAmountWithTax = (B * 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn
    *                       /
    *                       (A + 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn)
-   *                     = (B * 997 * (1 - amountIn.sellFeesBips / 10000) * amountIn
+ *                       = (B * 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn * 1000
    *                       /
-   *                       (1000 * A + 997 * (1 - amountIn.sellFeesBips / 10000) * amountIn)
+   *                       ((A + 0.997 * (1 - amountIn.sellFeesBips / 10000) * amountIn) * 1000)
+   *                     = (B * (1 - amountIn.sellFeesBips / 10000) 997 * * amountIn
+   *                       /
+   *                       (1000 * A + (1 - amountIn.sellFeesBips / 10000) * 997 * amountIn)
    *                     = (B * (1 - amountIn.sellFeesBips / 10000) * inputAmountWithFee)
    *                       /
    *                       (1000 * A + (1 - amountIn.sellFeesBips / 10000) * inputAmountWithFee)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,10 +1706,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@uniswap/sdk-core@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-4.0.2.tgz#2eca2b5bf00bad74519aef918465c19218285b4b"
-  integrity sha512-rR5xobsAAP4yMYC7C+0+duVx0pFoDn2lV9kTWpoKgH1WJuw7hD1uDEvuevU2dL89TuixVgGvnYd0QxmrMtsIlg==
+"@uniswap/sdk-core@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-4.0.7.tgz#90dfd070d7e44494234618af398da158363ae827"
+  integrity sha512-jscx7KUIWzQatcL5PHY6xy0gEL9IGQcL5h/obxzX9foP2KoNk9cq66Ia8I2Kvpa7zBcPOeW1hU0hJNBq6CzcIQ==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     big.js "^5.2.2"


### PR DESCRIPTION
When we quote against v2 pairs, if the token(s) is/are fee-on-transfer tokens, we essentially do not take them off the amountIn/amountOut. This is incorrect, and we want to consider the fee-on-transfer tokens when calculating the quotes in smart-order-router quote-provider [getQuotes](https://github.com/Uniswap/smart-order-router/blob/main/src/providers/v2/quote-provider.ts#L74-L98). 

One thing is that the reserves are not updated. Most likely fee-on-transfer tokens do deplete the reserves, so the correct calculations should take off of the reserves. However since smart-order-router refreshes reserves per block, and router doesn't persisted its own reserve state, we don't have to update the reserve calculation here.