### PR TITLE
Fix: FOT token tax retrieval source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/v2-sdk",
   "license": "MIT",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "🛠 An SDK for building applications on top of Uniswap V2",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/v2-sdk",
   "license": "MIT",
-  "version": "3.2.2",
+  "version": "3.2.1",
   "description": "🛠 An SDK for building applications on top of Uniswap V2",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -186,6 +186,14 @@ describe('Pair', () => {
       BLASTBuyFeeBps,
       BLASTSellFeeBps
     )
+    const BLAST_WIHTOUT_TAX = new Token(
+        ChainId.MAINNET,
+        '0x3ed643e9032230f01c6c36060e305ab53ad3b482',
+        18,
+        'BLAST',
+        'BLAST',
+        false
+    )
     const BLASTERSBuyFeeBps = BigNumber.from(300)
     const BLASTERSSellFeeBps = BigNumber.from(350)
     const BLASTERS = new Token(
@@ -197,6 +205,14 @@ describe('Pair', () => {
       false,
       BLASTERSBuyFeeBps,
       BLASTERSSellFeeBps
+    )
+    const BLASTERS_WITHOUT_TAX = new Token(
+        ChainId.MAINNET,
+        '0xab98093C7232E98A47D7270CE0c1c2106f61C73b',
+        9,
+        'BLAST',
+        'BLASTERS',
+        false
     )
 
     let calculateFotFees: boolean = false
@@ -213,7 +229,7 @@ describe('Pair', () => {
 
           const pair = new Pair(reserveBlasterAmount, reserveBlastAmount)
 
-          const inputBlastersAmount = CurrencyAmount.fromRawAmount(BLASTERS, '100')
+          const inputBlastersAmount = CurrencyAmount.fromRawAmount(BLASTERS_WITHOUT_TAX, '100')
           const [outputBlastAmount] = pair.getOutputAmount(inputBlastersAmount, calculateFotFees)
 
           // Theoretical amount out:
@@ -246,7 +262,7 @@ describe('Pair', () => {
 
           const pair = new Pair(reserveBlasterAmount, reserveBlastAmount)
 
-          const outputBlastAmount = CurrencyAmount.fromRawAmount(BLAST, '91')
+          const outputBlastAmount = CurrencyAmount.fromRawAmount(BLAST_WIHTOUT_TAX, '91')
           const [inputBlasterAmount] = pair.getInputAmount(outputBlastAmount, calculateFotFees)
 
           // Theoretical amount in:
@@ -294,7 +310,7 @@ describe('Pair', () => {
 
           const pair = new Pair(reserveBlasterAmount, reserveBlastAmount)
 
-          const inputBlastersAmount = CurrencyAmount.fromRawAmount(BLASTERS, '100')
+          const inputBlastersAmount = CurrencyAmount.fromRawAmount(BLASTERS_WITHOUT_TAX, '100')
           const [outputBlastAmount] = pair.getOutputAmount(inputBlastersAmount, calculateFotFees)
 
           const expectedOutputBlastAmount = '0.000000000000000098'
@@ -307,7 +323,7 @@ describe('Pair', () => {
 
           const pair = new Pair(reserveBlasterAmount, reserveBlastAmount)
 
-          const outputBlastAmount = CurrencyAmount.fromRawAmount(BLAST, '91')
+          const outputBlastAmount = CurrencyAmount.fromRawAmount(BLAST_WIHTOUT_TAX, '91')
           const [inputBlasterAmount] = pair.getInputAmount(outputBlastAmount, calculateFotFees)
 
           const expectedInputBlasterAmount = '0.000000093'

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -187,12 +187,12 @@ describe('Pair', () => {
       BLASTSellFeeBps
     )
     const BLAST_WIHTOUT_TAX = new Token(
-        ChainId.MAINNET,
-        '0x3ed643e9032230f01c6c36060e305ab53ad3b482',
-        18,
-        'BLAST',
-        'BLAST',
-        false
+      ChainId.MAINNET,
+      '0x3ed643e9032230f01c6c36060e305ab53ad3b482',
+      18,
+      'BLAST',
+      'BLAST',
+      false
     )
     const BLASTERSBuyFeeBps = BigNumber.from(300)
     const BLASTERSSellFeeBps = BigNumber.from(350)
@@ -207,12 +207,12 @@ describe('Pair', () => {
       BLASTERSSellFeeBps
     )
     const BLASTERS_WITHOUT_TAX = new Token(
-        ChainId.MAINNET,
-        '0xab98093C7232E98A47D7270CE0c1c2106f61C73b',
-        9,
-        'BLAST',
-        'BLASTERS',
-        false
+      ChainId.MAINNET,
+      '0xab98093C7232E98A47D7270CE0c1c2106f61C73b',
+      9,
+      'BLAST',
+      'BLASTERS',
+      false
     )
 
     let calculateFotFees: boolean = false

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -177,6 +177,7 @@ export class Pair {
    * outputAmountWithTax = amountOut * (1 - amountOut.buyFeesBips / 10000)
    *
    * @param inputAmount
+   * @param calculateFotFees
    */
   public getOutputAmount(
     inputAmount: CurrencyAmount<Token>,
@@ -379,7 +380,7 @@ export class Pair {
   }
 
   private derivePercentAfterSellFees(inputAmount: CurrencyAmount<Token>): Percent {
-    const sellFeeBips = inputAmount.currency.sellFeeBps
+    const sellFeeBips = this.token0.wrapped.equals(inputAmount.wrapped.currency) ? this.token0.wrapped.sellFeeBps : this.token1.wrapped.sellFeeBps;
     if (sellFeeBips?.gt(BigNumber.from(0))) {
       return ONE_HUNDRED_PERCENT.subtract(new Percent(JSBI.BigInt(sellFeeBips)).divide(BASIS_POINTS))
     } else {
@@ -388,7 +389,7 @@ export class Pair {
   }
 
   private derivePercentAfterBuyFees(outputAmount: CurrencyAmount<Token>): Percent {
-    const buyFeeBps = outputAmount.currency.buyFeeBps
+    const buyFeeBps = this.token0.wrapped.equals(outputAmount.wrapped.currency) ? this.token0.wrapped.buyFeeBps : this.token1.wrapped.buyFeeBps;
     if (buyFeeBps?.gt(BigNumber.from(0))) {
       return ONE_HUNDRED_PERCENT.subtract(new Percent(JSBI.BigInt(buyFeeBps)).divide(BASIS_POINTS))
     } else {

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -380,7 +380,9 @@ export class Pair {
   }
 
   private derivePercentAfterSellFees(inputAmount: CurrencyAmount<Token>): Percent {
-    const sellFeeBips = this.token0.wrapped.equals(inputAmount.wrapped.currency) ? this.token0.wrapped.sellFeeBps : this.token1.wrapped.sellFeeBps;
+    const sellFeeBips = this.token0.wrapped.equals(inputAmount.wrapped.currency)
+      ? this.token0.wrapped.sellFeeBps
+      : this.token1.wrapped.sellFeeBps
     if (sellFeeBips?.gt(BigNumber.from(0))) {
       return ONE_HUNDRED_PERCENT.subtract(new Percent(JSBI.BigInt(sellFeeBips)).divide(BASIS_POINTS))
     } else {
@@ -389,7 +391,9 @@ export class Pair {
   }
 
   private derivePercentAfterBuyFees(outputAmount: CurrencyAmount<Token>): Percent {
-    const buyFeeBps = this.token0.wrapped.equals(outputAmount.wrapped.currency) ? this.token0.wrapped.buyFeeBps : this.token1.wrapped.buyFeeBps;
+    const buyFeeBps = this.token0.wrapped.equals(outputAmount.wrapped.currency)
+      ? this.token0.wrapped.buyFeeBps
+      : this.token1.wrapped.buyFeeBps
     if (buyFeeBps?.gt(BigNumber.from(0))) {
       return ONE_HUNDRED_PERCENT.subtract(new Percent(JSBI.BigInt(buyFeeBps)).divide(BASIS_POINTS))
     } else {


### PR DESCRIPTION
We noticed a regression in the https://github.com/Uniswap/smart-order-router/pull/421 for FOT quote - if the token in is FOT, SOR no longer deducts the FOT tax off the quote. Note in the [PR](https://github.com/Uniswap/smart-order-router/pull/421/files#diff-604dffede13d2dd8277f5a7512a5ba0ff6fac291f2d0fb102c2af5f1711dedafL121-L129), how the first `outputAmountWithSellFeeBps` was passed into v2-sdk `Pair.getOutputAmount(inputAmount)`. Then the [PR](https://github.com/Uniswap/smart-order-router/pull/421/files#diff-604dffede13d2dd8277f5a7512a5ba0ff6fac291f2d0fb102c2af5f1711dedafR93-R96) changed to pass in `outputAmount` into v2-sdk `Pair.getOutputAmount(inputAmount)`.

- Prior to ship https://github.com/Uniswap/smart-order-router/pull/421, web FOT quote has double FOT taxation issue, hence https://github.com/Uniswap/smart-order-router/pull/421 was needed. 
- After shipping https://github.com/Uniswap/smart-order-router/pull/421, web FOT quote no longer has double FOT taxation issue. However if the token in is FOT, then the exact-in quote will be larger than the actual swap, and such swap failure rate will increase. For example, BLASTER => WETH swap success rate drops after shipping https://github.com/Uniswap/smart-order-router/pull/421, where before shipping https://github.com/Uniswap/smart-order-router/pull/421, BLASTER => WETH swap success rate was high, but MEV exploitation was non-trivial, with entire BLASTER sell tax of 3.5% being potential MEV profit for those MEV bots.
