### PR TITLE
fix: leave FACTORY_ADDRESS deprecated

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,11 @@
 import { Percent } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 
+/**
+ * @deprecated use FACTORY_ADDRESS_MAP instead
+ */
+export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+
 export const FACTORY_ADDRESS_MAP: { [chainId: number]: string } = {
   // Mainnet
   1: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',


### PR DESCRIPTION
undo a part of #151  - if we leave this constant but make it deprecated, we can avoid doing a major version bump.