### PR TITLE
Default FOT calculation to true

### DIFF
--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -181,7 +181,7 @@ export class Pair {
    */
   public getOutputAmount(
     inputAmount: CurrencyAmount<Token>,
-    calculateFotFees: boolean = false
+    calculateFotFees: boolean = true
   ): [CurrencyAmount<Token>, Pair] {
     invariant(this.involvesToken(inputAmount.currency), 'TOKEN')
     if (JSBI.equal(this.reserve0.quotient, ZERO) || JSBI.equal(this.reserve1.quotient, ZERO)) {
@@ -271,7 +271,7 @@ export class Pair {
    */
   public getInputAmount(
     outputAmount: CurrencyAmount<Token>,
-    calculateFotFees: boolean = false
+    calculateFotFees: boolean = true
   ): [CurrencyAmount<Token>, Pair] {
     invariant(this.involvesToken(outputAmount.currency), 'TOKEN')
     const percentAfterBuyFees = calculateFotFees ? this.derivePercentAfterBuyFees(outputAmount) : ZERO_PERCENT


### PR DESCRIPTION
We should be calculating FOT fees by default now, this would only work if the fees metadata for the tokens is provided in the Token object inside e CurrencyAmount
