### PR TITLE
Use default FACTORY_ADDRESS if the chain is not in the map

### DIFF
--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -1,8 +1,8 @@
-import {BigNumber} from '@ethersproject/bignumber'
-import {ChainId, CurrencyAmount, Price, Token, WETH9} from '@uniswap/sdk-core'
-import {FACTORY_ADDRESS} from '../constants';
-import {InsufficientInputAmountError} from '../errors'
-import {computePairAddress, Pair} from './pair'
+import { BigNumber } from '@ethersproject/bignumber'
+import { ChainId, CurrencyAmount, Price, Token, WETH9 } from '@uniswap/sdk-core'
+import { FACTORY_ADDRESS } from '../constants'
+import { InsufficientInputAmountError } from '../errors'
+import { computePairAddress, Pair } from './pair'
 
 describe('computePairAddress', () => {
   it('should correctly compute the pool address', () => {

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -1,8 +1,16 @@
+<<<<<<< Updated upstream
 import { BigNumber } from '@ethersproject/bignumber'
 import { ChainId, CurrencyAmount, Price, Token, WETH9 } from '@uniswap/sdk-core'
 import { FACTORY_ADDRESS } from 'constants'
 import { InsufficientInputAmountError } from '../errors'
 import { computePairAddress, Pair } from './pair'
+=======
+import {BigNumber} from '@ethersproject/bignumber'
+import {ChainId, CurrencyAmount, Price, Token, WETH9} from '@uniswap/sdk-core'
+import {FACTORY_ADDRESS} from '../constants';
+import {InsufficientInputAmountError} from '../errors'
+import {computePairAddress, Pair} from './pair'
+>>>>>>> Stashed changes
 
 describe('computePairAddress', () => {
   it('should correctly compute the pool address', () => {

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -1,8 +1,8 @@
-import {BigNumber} from '@ethersproject/bignumber'
-import {ChainId, CurrencyAmount, Price, Token, WETH9} from '@uniswap/sdk-core'
-import {FACTORY_ADDRESS} from 'constants';
-import {InsufficientInputAmountError} from '../errors'
-import {computePairAddress, Pair} from './pair'
+import { BigNumber } from '@ethersproject/bignumber'
+import { ChainId, CurrencyAmount, Price, Token, WETH9 } from '@uniswap/sdk-core'
+import { FACTORY_ADDRESS } from 'constants'
+import { InsufficientInputAmountError } from '../errors'
+import { computePairAddress, Pair } from './pair'
 
 describe('computePairAddress', () => {
   it('should correctly compute the pool address', () => {

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -1,7 +1,8 @@
-import { ChainId, CurrencyAmount, Price, Token, WETH9 } from '@uniswap/sdk-core'
-import { InsufficientInputAmountError } from '../errors'
-import { computePairAddress, Pair } from './pair'
-import { BigNumber } from '@ethersproject/bignumber'
+import {BigNumber} from '@ethersproject/bignumber'
+import {ChainId, CurrencyAmount, Price, Token, WETH9} from '@uniswap/sdk-core'
+import {FACTORY_ADDRESS} from 'constants';
+import {InsufficientInputAmountError} from '../errors'
+import {computePairAddress, Pair} from './pair'
 
 describe('computePairAddress', () => {
   it('should correctly compute the pool address', () => {
@@ -42,6 +43,9 @@ describe('Pair', () => {
   const USDC = new Token(1, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
   const DAI = new Token(1, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
 
+  const USDC_SEPOLIA = new Token(11155111, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
+  const DAI_SEPOLIA = new Token(11155111, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
+
   describe('constructor', () => {
     it('cannot be used for tokens on different chains', () => {
       expect(
@@ -53,6 +57,10 @@ describe('Pair', () => {
   describe('#getAddress', () => {
     it('returns the correct address', () => {
       expect(Pair.getAddress(USDC, DAI)).toEqual('0xAE461cA67B15dc8dc81CE7615e0320dA1A9aB8D5')
+    })
+
+    it('returns the default address for a testnet not in the map', () => {
+      expect(Pair.getAddress(USDC_SEPOLIA, DAI_SEPOLIA)).toEqual(FACTORY_ADDRESS)
     })
   })
 

--- a/src/entities/pair.test.ts
+++ b/src/entities/pair.test.ts
@@ -1,16 +1,8 @@
-<<<<<<< Updated upstream
-import { BigNumber } from '@ethersproject/bignumber'
-import { ChainId, CurrencyAmount, Price, Token, WETH9 } from '@uniswap/sdk-core'
-import { FACTORY_ADDRESS } from 'constants'
-import { InsufficientInputAmountError } from '../errors'
-import { computePairAddress, Pair } from './pair'
-=======
 import {BigNumber} from '@ethersproject/bignumber'
 import {ChainId, CurrencyAmount, Price, Token, WETH9} from '@uniswap/sdk-core'
 import {FACTORY_ADDRESS} from '../constants';
 import {InsufficientInputAmountError} from '../errors'
 import {computePairAddress, Pair} from './pair'
->>>>>>> Stashed changes
 
 describe('computePairAddress', () => {
   it('should correctly compute the pool address', () => {

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -1,7 +1,7 @@
-import {getCreate2Address} from '@ethersproject/address'
-import {BigNumber} from '@ethersproject/bignumber'
-import {keccak256, pack} from '@ethersproject/solidity'
-import {BigintIsh, CurrencyAmount, Percent, Price, sqrt, Token} from '@uniswap/sdk-core'
+import { getCreate2Address } from '@ethersproject/address'
+import { BigNumber } from '@ethersproject/bignumber'
+import { keccak256, pack } from '@ethersproject/solidity'
+import { BigintIsh, CurrencyAmount, Percent, Price, sqrt, Token } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 import invariant from 'tiny-invariant'
 
@@ -19,7 +19,7 @@ import {
   ZERO,
   ZERO_PERCENT
 } from '../constants'
-import {InsufficientInputAmountError, InsufficientReservesError} from '../errors'
+import { InsufficientInputAmountError, InsufficientReservesError } from '../errors'
 
 export const computePairAddress = ({
   factoryAddress,

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -1,24 +1,25 @@
-import { BigintIsh, Price, sqrt, Token, CurrencyAmount, Percent } from '@uniswap/sdk-core'
-import invariant from 'tiny-invariant'
+import {getCreate2Address} from '@ethersproject/address'
+import {BigNumber} from '@ethersproject/bignumber'
+import {keccak256, pack} from '@ethersproject/solidity'
+import {BigintIsh, CurrencyAmount, Percent, Price, sqrt, Token} from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
-import { pack, keccak256 } from '@ethersproject/solidity'
-import { getCreate2Address } from '@ethersproject/address'
-import { BigNumber } from '@ethersproject/bignumber'
+import invariant from 'tiny-invariant'
 
 import {
+  _1000,
+  _997,
+  BASIS_POINTS,
+  FACTORY_ADDRESS,
   FACTORY_ADDRESS_MAP,
+  FIVE,
   INIT_CODE_HASH,
   MINIMUM_LIQUIDITY,
-  FIVE,
-  _997,
-  _1000,
   ONE,
-  ZERO,
-  BASIS_POINTS,
   ONE_HUNDRED_PERCENT,
+  ZERO,
   ZERO_PERCENT
 } from '../constants'
-import { InsufficientReservesError, InsufficientInputAmountError } from '../errors'
+import {InsufficientInputAmountError, InsufficientReservesError} from '../errors'
 
 export const computePairAddress = ({
   factoryAddress,
@@ -41,7 +42,8 @@ export class Pair {
   private readonly tokenAmounts: [CurrencyAmount<Token>, CurrencyAmount<Token>]
 
   public static getAddress(tokenA: Token, tokenB: Token): string {
-    return computePairAddress({ factoryAddress: FACTORY_ADDRESS_MAP[tokenA.chainId], tokenA, tokenB })
+    const factoryAddress = FACTORY_ADDRESS_MAP[tokenA.chainId] ?? FACTORY_ADDRESS
+    return computePairAddress({ factoryAddress, tokenA, tokenB })
   }
 
   public constructor(currencyAmountA: CurrencyAmount<Token>, tokenAmountB: CurrencyAmount<Token>) {


### PR DESCRIPTION
# Fix `getAddress` method

We made a change in #151 that now relies on a map of factory address, but the problem is that if we are trying to quote a chain that is not on that map, then we just error out.

This change is default to the previously unique factory_address when the chain of the token is not in the map
